### PR TITLE
allow package requiring lines to have prefixing spaces

### DIFF
--- a/tex2nix/__init__.py
+++ b/tex2nix/__init__.py
@@ -31,7 +31,7 @@ def get_nix_packages() -> Set[str]:
 
 
 def get_packages(line: str) -> Set[str]:
-    match = re.match(r"\\(?:usepackage|RequirePackage).*{([^}]+)}", line)
+    match = re.match(r"\s*\\(?:usepackage|RequirePackage).*{([^}]+)}", line)
     if not match:
         return set()
     args = match.group(1)


### PR DESCRIPTION
Found this issue when my LaTeX template had:

```tex
\ifbool{iitthesis-abbrevs}{
  \RequirePackage[automake]{glossaries-extra}
  \RequirePackage{longtable}
```
